### PR TITLE
Update split_block.py

### DIFF
--- a/python/plot3d/split_block.py
+++ b/python/plot3d/split_block.py
@@ -223,6 +223,8 @@ def split_blocks(blocks:List[Block], ncells_per_block:int,direction:Direction=No
                     Y = block.Y[:,:,k:]
                     Z = block.Z[:,:,k:]                    
                     new_blocks.append(Block(X,Y,Z)) # replace it 
+        else:
+            new_blocks.append(block)
     return new_blocks
 
         

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plot3d"
-version = "1.4.9"
+version = "1.5.0"
 description = "Plot3D python utilities for reading and writing and also finding connectivity between blocks"
 authors = ["Paht Juangphanich <paht.juangphanich@nasa.gov>"]
 


### PR DESCRIPTION
Fixed a bug where meshes < cell count do not need to be split. Previously, these meshes were excluded. 