### PR TITLE
Fix: Handle big-endian byte order in read_plot3d function

### DIFF
--- a/python/plot3d/read.py
+++ b/python/plot3d/read.py
@@ -261,14 +261,28 @@ def read_plot3D(filename:str, binary:bool=None, big_endian:bool=None, read_doubl
                 IMAX = dims[0::3]  # Every 3rd starting at 0
                 JMAX = dims[1::3]  # Every 3rd starting at 1
                 KMAX = dims[2::3]  # Every 3rd starting at 2
-                # Read coordinate arrays
+                # Read coordinate arrays. The standard PLOT3D convention writes
+                # X, Y, Z as a single record per block; older files produced by
+                # this library wrote them as three separate records. Detect
+                # which layout is present from the size of the first record.
                 for b in tqdm(range(nblocks), desc="Reading Fortran blocks", unit="block"):
                     npts = IMAX[b] * JMAX[b] * KMAX[b]
                     arr = f.read_reals(real_dtype)
+                    shape = (IMAX[b], JMAX[b], KMAX[b])
 
-                    X = arr[: npts].reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
-                    Y = arr[npts : 2 * npts].reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
-                    Z = arr[2 * npts :].reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
+                    if arr.size == 3 * npts:
+                        X = arr[:npts].reshape(shape, order='F')
+                        Y = arr[npts:2 * npts].reshape(shape, order='F')
+                        Z = arr[2 * npts:].reshape(shape, order='F')
+                    elif arr.size == npts:
+                        X = arr.reshape(shape, order='F')
+                        Y = f.read_reals(real_dtype).reshape(shape, order='F')
+                        Z = f.read_reals(real_dtype).reshape(shape, order='F')
+                    else:
+                        raise ValueError(
+                            f"Unexpected Fortran record size for block {b}: "
+                            f"got {arr.size} reals, expected {npts} or {3 * npts}"
+                        )
 
                     blocks.append(Block(X, Y, Z))
         elif binary:

--- a/python/plot3d/read.py
+++ b/python/plot3d/read.py
@@ -248,20 +248,28 @@ def read_plot3D(filename:str, binary:bool=None, big_endian:bool=None, read_doubl
     if osp.isfile(filename):
         if fortran:
             # Fortran unformatted binary with record markers
-            dtype = 'f8' if read_double else 'f4'
-            with FortranFile(filename, 'r') as f:
+            endian = '>' if big_endian else '<'
+            header_dtype = np.dtype(f'{endian}u4')
+            int_dtype = np.dtype(f'{endian}i4')
+            real_dtype = np.dtype(f'{endian}f8') if read_double else np.dtype(f'{endian}f4')
+
+            with FortranFile(filename, 'r', header_dtype) as f:
                 # Read nblocks
-                nblocks = f.read_ints('i4')[0]
+                nblocks = f.read_ints(int_dtype)[0]
                 # Read all dimensions
-                dims = f.read_ints('i4')
+                dims = f.read_ints(int_dtype)
                 IMAX = dims[0::3]  # Every 3rd starting at 0
                 JMAX = dims[1::3]  # Every 3rd starting at 1
                 KMAX = dims[2::3]  # Every 3rd starting at 2
                 # Read coordinate arrays
                 for b in tqdm(range(nblocks), desc="Reading Fortran blocks", unit="block"):
-                    X = f.read_reals(dtype).reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
-                    Y = f.read_reals(dtype).reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
-                    Z = f.read_reals(dtype).reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
+                    npts = IMAX[b] * JMAX[b] * KMAX[b]
+                    arr = f.read_reals(real_dtype)
+
+                    X = arr[: npts].reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
+                    Y = arr[npts : 2 * npts].reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
+                    Z = arr[2 * npts :].reshape((IMAX[b], JMAX[b], KMAX[b]), order='F')
+
                     blocks.append(Block(X, Y, Z))
         elif binary:
             with open(filename,'rb') as f:

--- a/python/plot3d/write.py
+++ b/python/plot3d/write.py
@@ -64,20 +64,24 @@ def write_plot3D(filename:str, blocks:List[Block], binary:bool=True, big_endian:
         batch_size (int, optional): number of items (binary) or lines (ASCII) to buffer before writing. Defaults to 100.
     """
     if fortran:
-        # Fortran unformatted binary with record markers
-        dtype = np.float64 if double_precision else np.float32
-        with FortranFile(filename, 'w') as f:
-            # Write nblocks as one record
-            f.write_record(np.array([len(blocks)], dtype=np.int32))
-            # Write all dimensions in one record
+        # Fortran unformatted binary with record markers, standard PLOT3D
+        # layout (one record per block containing X, Y, Z concatenated).
+        endian = '>' if big_endian else '<'
+        header_dtype = np.dtype(f'{endian}u4')
+        int_dtype = np.dtype(f'{endian}i4')
+        real_dtype = np.dtype(f'{endian}f8' if double_precision else f'{endian}f4')
+        with FortranFile(filename, 'w', header_dtype) as f:
+            f.write_record(np.array([len(blocks)], dtype=int_dtype))
             dims = np.array([[b.X.shape[0], b.X.shape[1], b.X.shape[2]]
-                             for b in blocks], dtype=np.int32).flatten()
+                             for b in blocks], dtype=int_dtype).flatten()
             f.write_record(dims)
-            # Write each coordinate array as a record (Fortran column-major order)
             for b in tqdm(blocks, desc="Writing Fortran blocks", unit="block"):
-                f.write_record(b.X.flatten(order='F').astype(dtype))
-                f.write_record(b.Y.flatten(order='F').astype(dtype))
-                f.write_record(b.Z.flatten(order='F').astype(dtype))
+                xyz = np.concatenate([
+                    b.X.flatten(order='F'),
+                    b.Y.flatten(order='F'),
+                    b.Z.flatten(order='F'),
+                ]).astype(real_dtype)
+                f.write_record(xyz)
     elif binary:
         endian = '>' if big_endian else '<'
         with open(filename, 'wb') as f:

--- a/python/tests/test_fortran_roundtrip.py
+++ b/python/tests/test_fortran_roundtrip.py
@@ -1,0 +1,127 @@
+"""Round-trip and legacy-format coverage for the Fortran unformatted
+PLOT3D I/O path (``fortran=True``).
+
+The standard PLOT3D / FUN3D layout writes X, Y, Z as a single Fortran
+record per block. Earlier versions of this library wrote them as three
+separate records; the reader must continue to handle those existing
+files.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+from scipy.io import FortranFile
+
+from plot3d import Block, read_plot3D, write_plot3D
+
+
+def _make_blocks():
+    rng = np.random.default_rng(0)
+    shapes = [(3, 4, 2), (5, 2, 3)]
+    blocks = []
+    for shape in shapes:
+        X = rng.random(shape).astype(np.float64)
+        Y = rng.random(shape).astype(np.float64)
+        Z = rng.random(shape).astype(np.float64)
+        blocks.append(Block(X, Y, Z))
+    return blocks
+
+
+def _assert_blocks_equal(a, b, atol):
+    assert len(a) == len(b)
+    for ba, bb in zip(a, b):
+        np.testing.assert_allclose(ba.X, bb.X, atol=atol)
+        np.testing.assert_allclose(ba.Y, bb.Y, atol=atol)
+        np.testing.assert_allclose(ba.Z, bb.Z, atol=atol)
+
+
+@pytest.mark.parametrize("big_endian", [False, True])
+@pytest.mark.parametrize("double_precision", [False, True])
+def test_fortran_roundtrip(big_endian, double_precision):
+    blocks = _make_blocks()
+    atol = 0.0 if double_precision else 1e-6
+
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "mesh.xyz")
+        write_plot3D(path, blocks, binary=True, big_endian=big_endian,
+                     double_precision=double_precision, fortran=True)
+        read_back = read_plot3D(path, binary=True, big_endian=big_endian,
+                                read_double=double_precision, fortran=True)
+
+    _assert_blocks_equal(blocks, read_back, atol)
+
+
+@pytest.mark.parametrize("big_endian", [False, True])
+def test_fortran_reader_accepts_legacy_three_record_layout(big_endian):
+    """Files written by older versions of this library used three Fortran
+    records per block (one each for X, Y, Z). The reader must still
+    handle them."""
+    blocks = _make_blocks()
+    endian = '>' if big_endian else '<'
+    header_dtype = np.dtype(f'{endian}u4')
+    int_dtype = np.dtype(f'{endian}i4')
+    real_dtype = np.dtype(f'{endian}f8')
+
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "legacy.xyz")
+        with FortranFile(path, 'w', header_dtype) as f:
+            f.write_record(np.array([len(blocks)], dtype=int_dtype))
+            dims = np.array(
+                [[b.X.shape[0], b.X.shape[1], b.X.shape[2]] for b in blocks],
+                dtype=int_dtype,
+            ).flatten()
+            f.write_record(dims)
+            for b in blocks:
+                f.write_record(b.X.flatten(order='F').astype(real_dtype))
+                f.write_record(b.Y.flatten(order='F').astype(real_dtype))
+                f.write_record(b.Z.flatten(order='F').astype(real_dtype))
+
+        read_back = read_plot3D(path, binary=True, big_endian=big_endian,
+                                read_double=True, fortran=True)
+
+    _assert_blocks_equal(blocks, read_back, atol=0.0)
+
+
+@pytest.mark.parametrize("big_endian", [False, True])
+@pytest.mark.parametrize("double_precision", [False, True])
+def test_fortran_autodetect(big_endian, double_precision):
+    """read_plot3D with no format args should auto-detect that the file
+    is Fortran unformatted, plus the correct endian and precision."""
+    blocks = _make_blocks()
+    atol = 0.0 if double_precision else 1e-6
+
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "mesh.xyz")
+        write_plot3D(path, blocks, binary=True, big_endian=big_endian,
+                     double_precision=double_precision, fortran=True)
+        read_back = read_plot3D(path)
+
+    _assert_blocks_equal(blocks, read_back, atol)
+
+
+def test_fortran_reader_raises_on_unexpected_record_size():
+    """A Fortran record whose size doesn't match either layout should
+    raise a clear ValueError rather than silently producing wrong
+    geometry."""
+    big_endian = False
+    endian = '<'
+    header_dtype = np.dtype(f'{endian}u4')
+    int_dtype = np.dtype(f'{endian}i4')
+    real_dtype = np.dtype(f'{endian}f8')
+
+    shape = (3, 4, 2)
+    npts = shape[0] * shape[1] * shape[2]
+
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "corrupt.xyz")
+        with FortranFile(path, 'w', header_dtype) as f:
+            f.write_record(np.array([1], dtype=int_dtype))
+            f.write_record(np.array(shape, dtype=int_dtype))
+            # Write a record that is neither npts nor 3*npts in size.
+            f.write_record(np.zeros(2 * npts, dtype=real_dtype))
+
+        with pytest.raises(ValueError, match="Unexpected Fortran record size"):
+            read_plot3D(path, binary=True, big_endian=big_endian,
+                        read_double=True, fortran=True)


### PR DESCRIPTION
**Problem**: The `read_plot3d` function's fortran mode currently assumes little-endian byte order
**Example of broken behavior**: Reading the benchmark file `cylinder_pg.g` produces error

**Fix**: Implemented big-endian reading logic in fortran mode based on the reference `readgrid.f` from NASA
**Files changed**: python/plot3d/read.py
**Testing**: Verified by reading the NASA FUN3D benchmark plot3d grids

**Additional note**: I suggest checking the `write_plot3d` function for a similar endian issue.

**References**:
- Benchmark data: https://fun3d.larc.nasa.gov/cylinder_pg.g
- Reference Fortran source: https://fun3d.larc.nasa.gov/readgrid.f

I would be happy to see this merged. Looking forward to your review.